### PR TITLE
Fixes #11: Convert .pt to ONNX to fix memory bug

### DIFF
--- a/ONNX_conversion.ipynb
+++ b/ONNX_conversion.ipynb
@@ -1,0 +1,172 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install torch torchvision onnx onnxruntime ultralytics"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9exdyVL1suQ7",
+        "outputId": "84d292ee-d45c-4f32-cb05-9583b971d5a4"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: torch in /usr/local/lib/python3.11/dist-packages (2.6.0+cu124)\n",
+            "Requirement already satisfied: torchvision in /usr/local/lib/python3.11/dist-packages (0.21.0+cu124)\n",
+            "Requirement already satisfied: onnx in /usr/local/lib/python3.11/dist-packages (1.17.0)\n",
+            "Requirement already satisfied: onnxruntime in /usr/local/lib/python3.11/dist-packages (1.21.0)\n",
+            "Collecting ultralytics\n",
+            "  Downloading ultralytics-8.3.107-py3-none-any.whl.metadata (37 kB)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.11/dist-packages (from torch) (3.18.0)\n",
+            "Requirement already satisfied: typing-extensions>=4.10.0 in /usr/local/lib/python3.11/dist-packages (from torch) (4.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.11/dist-packages (from torch) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.11/dist-packages (from torch) (3.1.6)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.11/dist-packages (from torch) (2025.3.2)\n",
+            "Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.127)\n",
+            "Requirement already satisfied: nvidia-cuda-runtime-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.127)\n",
+            "Requirement already satisfied: nvidia-cuda-cupti-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.127)\n",
+            "Requirement already satisfied: nvidia-cudnn-cu12==9.1.0.70 in /usr/local/lib/python3.11/dist-packages (from torch) (9.1.0.70)\n",
+            "Requirement already satisfied: nvidia-cublas-cu12==12.4.5.8 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.5.8)\n",
+            "Requirement already satisfied: nvidia-cufft-cu12==11.2.1.3 in /usr/local/lib/python3.11/dist-packages (from torch) (11.2.1.3)\n",
+            "Requirement already satisfied: nvidia-curand-cu12==10.3.5.147 in /usr/local/lib/python3.11/dist-packages (from torch) (10.3.5.147)\n",
+            "Requirement already satisfied: nvidia-cusolver-cu12==11.6.1.9 in /usr/local/lib/python3.11/dist-packages (from torch) (11.6.1.9)\n",
+            "Requirement already satisfied: nvidia-cusparse-cu12==12.3.1.170 in /usr/local/lib/python3.11/dist-packages (from torch) (12.3.1.170)\n",
+            "Requirement already satisfied: nvidia-cusparselt-cu12==0.6.2 in /usr/local/lib/python3.11/dist-packages (from torch) (0.6.2)\n",
+            "Requirement already satisfied: nvidia-nccl-cu12==2.21.5 in /usr/local/lib/python3.11/dist-packages (from torch) (2.21.5)\n",
+            "Requirement already satisfied: nvidia-nvtx-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.127)\n",
+            "Requirement already satisfied: nvidia-nvjitlink-cu12==12.4.127 in /usr/local/lib/python3.11/dist-packages (from torch) (12.4.127)\n",
+            "Requirement already satisfied: triton==3.2.0 in /usr/local/lib/python3.11/dist-packages (from torch) (3.2.0)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.11/dist-packages (from torch) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.11/dist-packages (from sympy==1.13.1->torch) (1.3.0)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.11/dist-packages (from torchvision) (2.0.2)\n",
+            "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /usr/local/lib/python3.11/dist-packages (from torchvision) (11.1.0)\n",
+            "Requirement already satisfied: protobuf>=3.20.2 in /usr/local/lib/python3.11/dist-packages (from onnx) (5.29.4)\n",
+            "Requirement already satisfied: coloredlogs in /usr/local/lib/python3.11/dist-packages (from onnxruntime) (15.0.1)\n",
+            "Requirement already satisfied: flatbuffers in /usr/local/lib/python3.11/dist-packages (from onnxruntime) (25.2.10)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.11/dist-packages (from onnxruntime) (24.2)\n",
+            "Requirement already satisfied: matplotlib>=3.3.0 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (3.10.0)\n",
+            "Requirement already satisfied: opencv-python>=4.6.0 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (4.11.0.86)\n",
+            "Requirement already satisfied: pyyaml>=5.3.1 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (6.0.2)\n",
+            "Requirement already satisfied: requests>=2.23.0 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (2.32.3)\n",
+            "Requirement already satisfied: scipy>=1.4.1 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (1.14.1)\n",
+            "Requirement already satisfied: tqdm>=4.64.0 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (4.67.1)\n",
+            "Requirement already satisfied: psutil in /usr/local/lib/python3.11/dist-packages (from ultralytics) (5.9.5)\n",
+            "Requirement already satisfied: py-cpuinfo in /usr/local/lib/python3.11/dist-packages (from ultralytics) (9.0.0)\n",
+            "Requirement already satisfied: pandas>=1.1.4 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (2.2.2)\n",
+            "Requirement already satisfied: seaborn>=0.11.0 in /usr/local/lib/python3.11/dist-packages (from ultralytics) (0.13.2)\n",
+            "Collecting ultralytics-thop>=2.0.0 (from ultralytics)\n",
+            "  Downloading ultralytics_thop-2.0.14-py3-none-any.whl.metadata (9.4 kB)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (1.3.1)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (0.12.1)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (4.57.0)\n",
+            "Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (1.4.8)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (3.2.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=3.3.0->ultralytics) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas>=1.1.4->ultralytics) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas>=1.1.4->ultralytics) (2025.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests>=2.23.0->ultralytics) (3.4.1)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests>=2.23.0->ultralytics) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests>=2.23.0->ultralytics) (2.3.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests>=2.23.0->ultralytics) (2025.1.31)\n",
+            "Requirement already satisfied: humanfriendly>=9.1 in /usr/local/lib/python3.11/dist-packages (from coloredlogs->onnxruntime) (10.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.11/dist-packages (from jinja2->torch) (3.0.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.11/dist-packages (from python-dateutil>=2.7->matplotlib>=3.3.0->ultralytics) (1.17.0)\n",
+            "Downloading ultralytics-8.3.107-py3-none-any.whl (974 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m974.5/974.5 kB\u001b[0m \u001b[31m20.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading ultralytics_thop-2.0.14-py3-none-any.whl (26 kB)\n",
+            "Installing collected packages: ultralytics-thop, ultralytics\n",
+            "Successfully installed ultralytics-8.3.107 ultralytics-thop-2.0.14\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "6E3XXYuIso9_",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8cbf0602-0817-4755-e694-0c1e9af8f72e"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Creating new Ultralytics Settings v0.0.6 file ✅ \n",
+            "View Ultralytics Settings with 'yolo settings' or at '/root/.config/Ultralytics/settings.json'\n",
+            "Update Settings with 'yolo settings key=value', i.e. 'yolo settings runs_dir=path/to/dir'. For help see https://docs.ultralytics.com/quickstart/#ultralytics-settings.\n",
+            "Ultralytics 8.3.107 🚀 Python-3.11.12 torch-2.6.0+cu124 CPU (Intel Xeon 2.20GHz)\n",
+            "YOLO11x summary (fused): 190 layers, 56,838,574 parameters, 0 gradients, 194.5 GFLOPs\n",
+            "\n",
+            "\u001b[34m\u001b[1mPyTorch:\u001b[0m starting from '/content/visocc_yolo v11x.pt' with input shape (1, 3, 640, 640) BCHW and output shape(s) (1, 14, 8400) (109.1 MB)\n",
+            "\u001b[31m\u001b[1mrequirements:\u001b[0m Ultralytics requirement ['onnxslim'] not found, attempting AutoUpdate...\n",
+            "Collecting onnxslim\n",
+            "  Downloading onnxslim-0.1.50-py3-none-any.whl.metadata (4.8 kB)\n",
+            "Requirement already satisfied: onnx in /usr/local/lib/python3.11/dist-packages (from onnxslim) (1.17.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.11/dist-packages (from onnxslim) (1.13.1)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.11/dist-packages (from onnxslim) (24.2)\n",
+            "Requirement already satisfied: numpy>=1.20 in /usr/local/lib/python3.11/dist-packages (from onnx->onnxslim) (2.0.2)\n",
+            "Requirement already satisfied: protobuf>=3.20.2 in /usr/local/lib/python3.11/dist-packages (from onnx->onnxslim) (5.29.4)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.11/dist-packages (from sympy->onnxslim) (1.3.0)\n",
+            "Downloading onnxslim-0.1.50-py3-none-any.whl (144 kB)\n",
+            "   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 144.5/144.5 kB 6.7 MB/s eta 0:00:00\n",
+            "Installing collected packages: onnxslim\n",
+            "Successfully installed onnxslim-0.1.50\n",
+            "\n",
+            "\u001b[31m\u001b[1mrequirements:\u001b[0m AutoUpdate success ✅ 4.1s, installed 1 package: ['onnxslim']\n",
+            "\u001b[31m\u001b[1mrequirements:\u001b[0m ⚠️ \u001b[1mRestart runtime or rerun command for updates to take effect\u001b[0m\n",
+            "\n",
+            "\n",
+            "\u001b[34m\u001b[1mONNX:\u001b[0m starting export with onnx 1.17.0 opset 12...\n",
+            "\u001b[34m\u001b[1mONNX:\u001b[0m slimming with onnxslim 0.1.50...\n",
+            "\u001b[34m\u001b[1mONNX:\u001b[0m export success ✅ 18.5s, saved as '/content/visocc_yolo v11x.onnx' (217.1 MB)\n",
+            "\n",
+            "Export complete (32.7s)\n",
+            "Results saved to \u001b[1m/content\u001b[0m\n",
+            "Predict:         yolo predict task=detect model=/content/visocc_yolo v11x.onnx imgsz=640  \n",
+            "Validate:        yolo val task=detect model=/content/visocc_yolo v11x.onnx imgsz=640 data=/usr/local/lib/python3.11/dist-packages/ultralytics/cfg/datasets/VisDrone.yaml  \n",
+            "Visualize:       https://netron.app\n",
+            "✅ YOLOv11x model exported to ONNX successfully!\n"
+          ]
+        }
+      ],
+      "source": [
+        "# ✅ Import YOLO from ultralytics\n",
+        "from ultralytics import YOLO\n",
+        "\n",
+        "# ✅ Load the YOLOv11x model\n",
+        "model = YOLO(\"/content/visocc_yolo v11x.pt\")\n",
+        "\n",
+        "# ✅ Export to ONNX format\n",
+        "model.export(format='onnx', imgsz=(640, 640), opset=12)\n",
+        "\n",
+        "# ✅ Done!\n",
+        "print(\"✅ YOLOv11x model exported to ONNX successfully!\")"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #11  
This PR addresses the high memory usage issue with the `.pt` model by:

- Including a notebook (`ONNX_conversion.ipynb`) for reproducibility and future updates

The ONNX model is more browser/inference-friendly and resolves memory spikes experienced with `.pt` deployment.